### PR TITLE
Change tickets.list_tickets() to use the data from the original reque…

### DIFF
--- a/freshdesk/api.py
+++ b/freshdesk/api.py
@@ -38,7 +38,7 @@ class TicketAPI(object):
             tickets += this_page
             page += 1
 
-        return [self.get_ticket(t['display_id']) for t in tickets]
+        return [Ticket(**t) for t in tickets]
 
     def list_all_tickets(self):
         """List all tickets, closed or open."""


### PR DESCRIPTION
…st for constructing Ticket objects rather than querying each ticket individually

just a little change with big impact.
We've been using Freshdesk for a few months, number of tickets increased, lately we've been running against call limits to the API. Turns out this method queries each ticket individually after receiving the list which already contains all the information. Hence the amount of API calls needed is reduced drastically, especially when using unfiltered lists.
