### PR TITLE
Allow clients to specify empty filter name

### DIFF
--- a/freshdesk/v1/api.py
+++ b/freshdesk/v1/api.py
@@ -16,14 +16,15 @@ class TicketAPI(object):
         """List all tickets, optionally filtered by a view. Specify filters as
         keyword arguments, such as:
 
-        filter_name = one of ['all_tickets', 'new_my_open', 'spam', 'deleted']
-            (defaults to 'all_tickets')
+        filter_name = one of ['all_tickets', 'new_my_open', 'spam', 'deleted',
+                               None]
+            (defaults to 'all_tickets'; passing None uses the default)
 
         Multiple filters are AND'd together.
         """
 
         filter_name = 'all_tickets'
-        if 'filter_name' in kwargs:
+        if 'filter_name' in kwargs and kwargs['filter_name'] is not None:
             filter_name = kwargs['filter_name']
             del kwargs['filter_name']
 

--- a/freshdesk/v1/test.py
+++ b/freshdesk/v1/test.py
@@ -146,6 +146,12 @@ class TestTicket(TestCase):
         self.assertEqual(len(tickets), 1)
         self.assertEqual(tickets[0].display_id, self.ticket.display_id)
 
+    def test_none_filter_name(self):
+        tickets = self.api.tickets.list_tickets(filter_name=None)
+        self.assertIsInstance(tickets, list)
+        self.assertEqual(len(tickets), 1)
+        self.assertEqual(tickets[0].display_id, self.ticket.display_id)
+
 
 class TestComment(TestCase):
     @classmethod

--- a/freshdesk/v2/api.py
+++ b/freshdesk/v2/api.py
@@ -43,8 +43,12 @@ class TicketAPI(object):
         """List all tickets, optionally filtered by a view. Specify filters as
         keyword arguments, such as:
 
-        filter_name = one of ['new_and_my_open', 'watching', 'spam', 'deleted']
+        filter_name = one of ['new_and_my_open', 'watching', 'spam', 'deleted',
+                              None]
             (defaults to 'new_and_my_open')
+            Passing None means that no named filter will be passed to
+            Freshdesk, which mimics the behavior of the 'all_tickets' filter
+            in v1 of the API.
 
         Multiple filters are AND'd together.
         """
@@ -54,14 +58,18 @@ class TicketAPI(object):
             filter_name = kwargs['filter_name']
             del kwargs['filter_name']
 
-        url = 'tickets?filter=%s' % filter_name
+        url = 'tickets'
+        if filter_name is not None:
+            url += '?filter=%s&' % filter_name
+        else:
+            url += '?'
         page = 1
         per_page = 100
         tickets = []
 
         # Skip pagination by looping over each page and adding tickets
         while True:
-            this_page = self._api._get(url + '&page=%d&per_page=%d'
+            this_page = self._api._get(url + 'page=%d&per_page=%d'
                                        % (page, per_page), kwargs)
             tickets += this_page
             if len(this_page) < per_page:

--- a/freshdesk/v2/test.py
+++ b/freshdesk/v2/test.py
@@ -26,6 +26,7 @@ class MockedAPI(API):
             re.compile(r'tickets\?filter=deleted&page=1&per_page=100'): self.read_test_file('all_tickets.json'),
             re.compile(r'tickets\?filter=spam&page=1&per_page=100'): self.read_test_file('all_tickets.json'),
             re.compile(r'tickets\?filter=watching&page=1&per_page=100'): self.read_test_file('all_tickets.json'),
+            re.compile(r'tickets\?page=1&per_page=100'): self.read_test_file('all_tickets.json'),
             re.compile(r'tickets/1$'): self.read_test_file('ticket_1.json'),
             re.compile(r'tickets/1/conversations'): self.read_test_file('conversations.json'),
             re.compile(r'contacts/1$'): self.read_test_file('contact.json'),
@@ -195,6 +196,12 @@ class TestTicket(TestCase):
 
     def test_default_filter_name(self):
         tickets = self.api.tickets.list_tickets()
+        self.assertIsInstance(tickets, list)
+        self.assertEqual(len(tickets), 1)
+        self.assertEqual(tickets[0].id, self.ticket.id)
+
+    def test_none_filter_name(self):
+        tickets = self.api.tickets.list_tickets(filter_name=None)
         self.assertIsInstance(tickets, list)
         self.assertEqual(len(tickets), 1)
         self.assertEqual(tickets[0].id, self.ticket.id)


### PR DESCRIPTION
Permits passing the kwarg `filter_name=None` to the `api.TicketAPI.list_tickets()` methods in both the `v1` and `v2` modules.

In v2 of the FD API, there is no `'all_tickets'` filter as there is in v1; one gets the same behavior by omitting the `filter` argument from the endpoint's GET parameters. Passing `None` as the filter name to the v2 API object does exactly this.

To maintain parity between the two versions' modules, passing a `filter_name=None` kwarg to `v1.api.TicketAPI.list_tickets()` selects the default `'all_tickets'` filter (the same behavior as omitting the kwarg).

Adds relevant tests.
