### PR TITLE
FRESHDESK API V1 DEPRECATION.

### DIFF
--- a/freshdesk/api.py
+++ b/freshdesk/api.py
@@ -33,11 +33,14 @@ def API(domain, api_key, version=1, **kwargs):
             For more info about freshdesk V2 API, visit https://developers.freshdesk.com/api/
             
             Now python-freshdesk library will by default return V2 API client. You need to migrate your project accordingly.
+            
+            
         """
         print(deprecation_message)
+        version = 2
 
     if version != 2:
-        print("Freshdesk V%d API is not released yet. Returning default V2 API client")
+        print("Freshdesk V%d API is not released yet. Returning default V2 API client\n" % version)
 
     version = 2
     client_class = _VERSIONS[version]

--- a/freshdesk/api.py
+++ b/freshdesk/api.py
@@ -25,5 +25,20 @@ def API(domain, api_key, version=1, **kwargs):
     except AttributeError:
         pass
 
+    if version == 1:
+        deprecation_message = """
+            Freshdesk has deprecated their V1 API from 1st July, 2018.
+            For more info, visit https://support.freshdesk.com/support/solutions/articles/231955-important-deprecation-of-api-v1
+            
+            For more info about freshdesk V2 API, visit https://developers.freshdesk.com/api/
+            
+            Now python-freshdesk library will by default return V2 API client. You need to migrate your project accordingly.
+        """
+        print(deprecation_message)
+
+    if version != 2:
+        print("Freshdesk V%d API is not released yet. Returning default V2 API client")
+
+    version = 2
     client_class = _VERSIONS[version]
     return client_class(domain, api_key, **kwargs)

--- a/freshdesk/v2/api.py
+++ b/freshdesk/v2/api.py
@@ -79,16 +79,17 @@ class TicketAPI(object):
             url += '?filter=%s&' % filter_name
         else:
             url += '?'
-        page = 1
-        per_page = 100
+        page = 1 if not 'page' in kwargs else kwargs['page']
+        per_page = 100 if not 'per_page' in kwargs else kwargs['per_page']
         tickets = []
 
-        # Skip pagination by looping over each page and adding tickets
+        # Skip pagination by looping over each page and adding tickets if 'page' key is not in kwargs.
+        # else return the requested page and break the loop
         while True:
             this_page = self._api._get(url + 'page=%d&per_page=%d'
                                        % (page, per_page), kwargs)
             tickets += this_page
-            if len(this_page) < per_page:
+            if len(this_page) < per_page or 'page' in kwargs:
                 break
             page += 1
 
@@ -175,16 +176,13 @@ class ContactAPI(object):
         """
 
         url = 'contacts?'
-        if kwargs:
-            for filter_name, filter_value in kwargs.items():
-                url = url + "{}={}&".format(filter_name, filter_value)
-                del kwargs[filter_name]
-
         page = 1 if not 'page' in kwargs else kwargs['page']
-        per_page = 10 if not 'per_page' in kwargs else kwargs['per_page']
+        per_page = 100 if not 'per_page' in kwargs else kwargs['per_page']
+
         contacts = []
 
-        # Skip pagination by looping over each page and adding contacts
+        # Skip pagination by looping over each page and adding tickets if 'page' key is not in kwargs.
+        # else return the requested page and break the loop
         while True:
             this_page = self._api._get(url + 'page=%d&per_page=%d'
                                        % (page, per_page), kwargs)
@@ -303,21 +301,18 @@ class AgentAPI(object):
         """
 
         url = 'agents?'
-        if kwargs:
-            for filter_name, filter_value in kwargs.items():
-                url = url + "{}={}&".format(filter_name, filter_value)
-                del kwargs[filter_name]
+        page = 1 if not 'page' in kwargs else kwargs['page']
+        per_page = 100 if not 'per_page' in kwargs else kwargs['per_page']
 
-        page = 1
-        per_page = 100
         agents = []
 
-        # Skip pagination by looping over each page and adding tickets
+        # Skip pagination by looping over each page and adding tickets if 'page' key is not in kwargs.
+        # else return the requested page and break the loop
         while True:
             this_page = self._api._get(url + 'page=%d&per_page=%d'
                                        % (page, per_page), kwargs)
             agents += this_page
-            if len(this_page) < per_page:
+            if len(this_page) < per_page or 'page' in kwargs:
                 break
             page += 1
 

--- a/freshdesk/v2/api.py
+++ b/freshdesk/v2/api.py
@@ -379,7 +379,14 @@ class API(object):
             req.raise_for_status()
             j = {}
 
-        if 'error' in j:
+        if 'Retry-After' in req.headers:
+            raise HTTPError('429 Rate Limit Exceeded: API rate-limit has been reached until {} seconds.'
+                            'See http://freshdesk.com/api#ratelimit'.format(req.headers['Retry-After']))
+
+        if 'code' in j and j['code'] == "invalid_credentials":
+            raise HTTPError('401 Unauthorized: Please login with correct credentials')
+
+        if 'errors' in j:
             raise HTTPError('{}: {}'.format(j.get('description'),
                                             j.get('errors')))
 

--- a/freshdesk/v2/test.py
+++ b/freshdesk/v2/test.py
@@ -31,7 +31,7 @@ class MockedAPI(API):
                 re.compile(r'tickets\?page=1&per_page=100'): self.read_test_file('all_tickets.json'),
                 re.compile(r'tickets/1$'): self.read_test_file('ticket_1.json'),
                 re.compile(r'tickets/1/conversations'): self.read_test_file('conversations.json'),
-                re.compile(r'contacts\?page=1&per_page=10$'): self.read_test_file('contacts.json'),
+                re.compile(r'contacts\?page=1&per_page=100$'): self.read_test_file('contacts.json'),
                 re.compile(r'contacts/1$'): self.read_test_file('contact.json'),
                 re.compile(r'customers/1$'): self.read_test_file('customer.json'),
                 re.compile(r'groups$'): self.read_test_file('groups.json'),


### PR DESCRIPTION
Freshdesk has deprecated their V1 API from 1st July, 2018.
For more info, visit https://support.freshdesk.com/support/solutions/articles/231955-important-deprecation-of-api-v1

For more info about freshdesk V2 API, visit https://developers.freshdesk.com/api/

Now python-freshdesk library will by default return V2 API client. Users need to migrate their project accordingly.

Also fixed some pagination issues. If page and per_page param is given, then return the requested page and dont loop for all pages.