### PR TITLE
Add the update_contact() call to the ContactAPI

### DIFF
--- a/freshdesk/v2/api.py
+++ b/freshdesk/v2/api.py
@@ -208,6 +208,10 @@ class ContactAPI(object):
         url = 'contacts/%d' % contact_id
         return Contact(**self._api._get(url))
 
+    def update_contact(self, contact_id, **data):
+        url = 'contacts/%d' % contact_id
+        return Contact(**self._api._put(url, data=json.dumps(data)))
+
     def soft_delete_contact(self, contact_id):
         url = 'contacts/%d' % contact_id
         self._api._delete(url)

--- a/freshdesk/v2/api.py
+++ b/freshdesk/v2/api.py
@@ -216,6 +216,10 @@ class ContactAPI(object):
         url = 'contacts/%d' % contact_id
         self._api._delete(url)
 
+    def restore_contact(self, contact_id):
+        url = 'contacts/%d/restore' % contact_id
+        self._api._put(url)
+
     def permanently_delete_contact(self, contact_id, force=True):
         url = 'contacts/%d/hard_delete?force=%r' % (contact_id, force)
         self._api._delete(url)


### PR DESCRIPTION
This adds the missing method for the `PUT` call: https://developer.freshdesk.com/api/#update_contact