### PR TITLE
Support binary ticket attachments

### DIFF
--- a/freshdesk/v2/api.py
+++ b/freshdesk/v2/api.py
@@ -45,7 +45,7 @@ class TicketAPI(object):
 
         for attachment in attachments:
             file_name = attachment.split("/")[-1:][0]
-            multipart_data.append(('attachments[]', (file_name, open(attachment), None)))
+            multipart_data.append(('attachments[]', (file_name, open(attachment, 'rb'), None)))
 
         ticket = self._api._post(url, data=data, files=multipart_data)
         return ticket


### PR DESCRIPTION
Copied from @haiiiiiyun's [snippet](https://github.com/sjkingo/python-freshdesk/issues/36#issuecomment-485713725) in #36

Tested in my code, works both for binary and non-binary attachments.