### PR TITLE
Fix encoding and content-type when creating tickets with attachments

### DIFF
--- a/freshdesk/v2/tests/test_ticket.py
+++ b/freshdesk/v2/tests/test_ticket.py
@@ -1,7 +1,7 @@
 import datetime
 import json
 import os.path
-from unittest.mock import patch, ANY
+from mock import patch, ANY
 
 import pytest
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,7 @@
 coveralls
 pytest
 pytest-cov
+mock
 python-dateutil
 requests
 responses


### PR DESCRIPTION
Since the ability to create tickets with attachments was added, there seems to have been a change in the Freshdesk API which stopped our approach from working. Freshdesk started returning the following response whenever you would try to create a ticket with an attachment:
`502: Incomplete response received from application` (a standard Rails error message)

The way it used to work, I think, is the following:
1. We pass a dictionary with all the ticket properties and a list of files to `requests`
2. `requests` sends a request with some JSON and some files with `Content-Type: application/json`  (technically invalid, but that's what is [set in the session](https://github.com/ArtemGordinsky/python-freshdesk/blob/attachments-multipart-fix/freshdesk/v2/api.py#L434))
3. Freshdesk magically separates JSON from the binary file data
4. A ticket is created with all the correct fields and attachments

The way it has to work from now on:
1. We reformat all of the provided arguments into a format suitable for `multipart/form-data` encoding
2. We override the `application/json` content-type initially set on the session (to `None`)
3. `requests` sends a fully formed, valid request of content-type `multipart/form-data` because we passed it a list of files
4. A ticket is created with all the correct fields and attachments

This makes ticket creation with attachments work again on my project, but feel free to test yourself and let me know if this makes sense to you 🙂 