### PR TITLE
Remove redundant files handler from v2 API._post

### DIFF
--- a/freshdesk/v2/api.py
+++ b/freshdesk/v2/api.py
@@ -498,10 +498,6 @@ class API(object):
 
     def _post(self, url, data={}, **kwargs):
         """Wrapper around request.post() to use the API prefix. Returns a JSON response."""
-        if 'files' in kwargs:
-            req = self._session.post(self._api_prefix + url, auth=self._session.auth, data=data, **kwargs)
-            return self._action(req)
-
         req = self._session.post(self._api_prefix + url, data=data, **kwargs)
         return self._action(req)
 


### PR DESCRIPTION
Adding usage of `requests.Session` and merging PR #35 resulted in duplicated code in `API._post`. Right now all of the attachments handling is performed in `_create_ticket_with_attachment` method and there no more need in separate API if-branch.
