### PR TITLE
Remove repr for query

### DIFF
--- a/freshdesk/v2/api.py
+++ b/freshdesk/v2/api.py
@@ -160,7 +160,7 @@ class TicketAPI(object):
 
         tickets = []
         while True:
-            this_page = self._api._get(url + 'page=%d&query=%s'
+            this_page = self._api._get(url + 'page=%d&query="%s"'
                                        % (page, query), kwargs)
             this_page = this_page['results']
             tickets += this_page

--- a/freshdesk/v2/api.py
+++ b/freshdesk/v2/api.py
@@ -161,7 +161,7 @@ class TicketAPI(object):
         tickets = []
         while True:
             this_page = self._api._get(url + 'page=%d&query=%s'
-                                       % (page, repr(query)), kwargs)
+                                       % (page, query), kwargs)
             this_page = this_page['results']
             tickets += this_page
             if len(this_page) < per_page or page == 10 or 'page' in kwargs:

--- a/freshdesk/v2/api.py
+++ b/freshdesk/v2/api.py
@@ -160,8 +160,8 @@ class TicketAPI(object):
 
         tickets = []
         while True:
-            this_page = self._api._get(url + 'page=%d&query="%s"'
-                                       % (page, query), kwargs)
+            this_page = self._api._get(url + 'page={}&query="{}"'.format(page, query),
+                                        kwargs)
             this_page = this_page['results']
             tickets += this_page
             if len(this_page) < per_page or page == 10 or 'page' in kwargs:

--- a/freshdesk/v2/api.py
+++ b/freshdesk/v2/api.py
@@ -154,6 +154,9 @@ class TicketAPI(object):
 
         query = "(ticket_field:integer OR ticket_field:'string') AND ticket_field:boolean"
         """
+        if(len(query)):
+            raise AttributeError('Query string can have up to 512 characters')
+        
         url = 'search/tickets?'
         page = 1 if not 'page' in kwargs else kwargs['page']
         per_page = 30

--- a/freshdesk/v2/api.py
+++ b/freshdesk/v2/api.py
@@ -154,7 +154,7 @@ class TicketAPI(object):
 
         query = "(ticket_field:integer OR ticket_field:'string') AND ticket_field:boolean"
         """
-        if(len(query)):
+        if(len(query) > 512):
             raise AttributeError('Query string can have up to 512 characters')
         
         url = 'search/tickets?'


### PR DESCRIPTION
Hello .. Good night,
The "repr ()" method was incorrectly adding quotation marks to the query, and freshdesk documentation is not allowed.