### PR TITLE
Added delete_company to v2 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ It includes the following features from the [Freshdesk v2 API](https://developer
     - [Get](http://developer.freshdesk.com/api/#view_company)
     - [List](http://developer.freshdesk.com/api/#list_all_companies) (from 1.2.8)
     - [Filter](https://developers.freshdesk.com/api/#filter_companies) (from 1.3.2)
+    - [Delete](https://developers.freshdesk.com/api/#delete_company)
 * [Roles](https://developers.freshdesk.com/api/#roles) (from 1.1.1)
     - [Get](http://developer.freshdesk.com/api/#view_role)
     - [List](http://developer.freshdesk.com/api/#list_role)

--- a/freshdesk/v2/api.py
+++ b/freshdesk/v2/api.py
@@ -398,6 +398,11 @@ class CompanyAPI(object):
             page += 1
 
         return [Company(**c) for c in companies]
+    
+    def delete_company(self, company_id):
+        """Delete the company for the given company ID"""
+        url = "companies/%d" % company_id
+        self._api._delete(url)
 
 
 class RoleAPI(object):

--- a/freshdesk/v2/tests/conftest.py
+++ b/freshdesk/v2/tests/conftest.py
@@ -61,6 +61,7 @@ class MockedAPI(API):
                 re.compile(r"agents/1$"): None,
                 re.compile(r"contacts/1$"): None,
                 re.compile(r"contacts/1/hard_delete\?force=True$"): None,
+                re.compile(r"companies/1$"): None
             },
         }
 

--- a/freshdesk/v2/tests/test_company.py
+++ b/freshdesk/v2/tests/test_company.py
@@ -46,3 +46,6 @@ def test_filter_query(api):
     assert isinstance(companies[0], Company)
     assert len(companies) == 2
     assert "lexcorp.org" in companies[0].domains
+
+def test_delete_company(api):
+    assert api.companies.delete_company(1) is None


### PR DESCRIPTION
Added delete_company(company_id) method to the v2 company API.
Added test for delete_company method.
Updated readme to indicate that the delete call is available for the company API.