### PR TITLE
Added time entry to the main API object

### DIFF
--- a/freshdesk/v2/api.py
+++ b/freshdesk/v2/api.py
@@ -556,6 +556,7 @@ class API(object):
         self.agents = AgentAPI(self)
         self.roles = RoleAPI(self)
         self.ticket_fields = TicketFieldAPI(self)
+        self.time_entry = TimeEntryAPI(self)
 
         if domain.find("freshdesk.com") < 0:
             raise AttributeError("Freshdesk v2 API works only via Freshdesk" "domains and not via custom CNAMEs")


### PR DESCRIPTION
There was a missing link between the main API object and the time entry object, so it's added now.